### PR TITLE
Reverting hyper binding to super

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,3 +1,13 @@
+void setBuildStatus(String message, String state) {
+    step([
+    $class: "GitHubCommitStatusSetter",
+    reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/bdemirtas/.emacs.d"],
+    contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "ci/jenkins/build-status"],
+    errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+    statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+    ]);
+}
+
 pipeline {
     agent any
     environment {
@@ -34,6 +44,14 @@ pipeline {
             steps{
                 sh 'emacs --debug-init --batch -u root'
             }
+        }
+    }
+    post {
+        success {
+            setBuildStatus("Build succeeded", "SUCCESS");
+        }
+        failure {
+            setBuildStatus("Build failed", "FAILURE");
         }
     }
 }

--- a/modules/buffer.module.el
+++ b/modules/buffer.module.el
@@ -157,72 +157,17 @@
   :hook ((java-mode kotlin-mode go-mode) . subword-mode))
 
 (use-package multiple-cursors
-  :functions hydra-multiple-cursors
-  :bind
-  ("C-c C-m" . hydra-multiple-cursors/body)
-  :preface
-  ;; insert specific serial number
-  (defvar ladicle/mc/insert-numbers-hist nil)
-  (defvar ladicle/mc/insert-numbers-inc 1)
-  (defvar ladicle/mc/insert-numbers-pad "%01d")
-
-  (defun ladicle/mc/insert-numbers (start inc pad)
-    "Insert increasing numbers for each cursor specifically."
-    (interactive
-     (list (read-number "Start from: " 0)
-           (read-number "Increment by: " 1)
-           (read-string "Padding (%01d): " nil ladicle/mc/insert-numbers-hist "%01d")))
-    (setq mc--insert-numbers-number start)
-    (setq ladicle/mc/insert-numbers-inc inc)
-    (setq ladicle/mc/insert-numbers-pad pad)
-    (mc/for-each-cursor-ordered
-     (mc/execute-command-for-fake-cursor
-      'ladicle/mc--insert-number-and-increase
-      cursor)))
-
-  (defun ladicle/mc--insert-number-and-increase ()
-    (interactive)
-    (insert (format ladicle/mc/insert-numbers-pad mc--insert-numbers-number))
-    (setq mc--insert-numbers-number (+ mc--insert-numbers-number ladicle/mc/insert-numbers-inc)))
-
   :config
-  (with-eval-after-load 'hydra
-    (defhydra hydra-multiple-cursors (:color pink :hint nil)
-"
-                                                                        ╔════════╗
-    Point^^^^^^             Misc^^            Insert                            ║ Cursor ║
-  ──────────────────────────────────────────────────────────────────────╨────────╜
-     _k_    _K_    _M-k_    [_l_] edit lines  [_i_] 0...
-     ^↑^    ^↑^     ^↑^     [_m_] mark all    [_a_] letters
-    mark^^ skip^^^ un-mk^   [_s_] sort        [_n_] numbers
-     ^↓^    ^↓^     ^↓^
-     _j_    _J_    _M-j_
-  ╭──────────────────────────────────────────────────────────────────────────────╯
-                           [_q_]: quit, [Click]: point
-"
-          ("l" mc/edit-lines)
-          ("m" mc/mark-all-like-this)
-          ("j" mc/mark-next-like-this)
-          ("J" mc/skip-to-next-like-this)
-          ("M-j" mc/unmark-next-like-this)
-          ("k" mc/mark-previous-like-this)
-          ("K" mc/skip-to-previous-like-this)
-          ("M-k" mc/unmark-previous-like-this)
-          ("s" mc/mark-all-in-region-regexp)
-          ("i" mc/insert-numbers)
-          ("a" mc/insert-letters)
-          ("n" ladicle/mc/insert-numbers)
-          ("<mouse-1>" mc/add-cursor-on-click)
-          ;; Help with click recognition in this hydra
-          ("<down-mouse-1>" ignore)
-          ("<drag-mouse-1>" ignore)
-          ("q" nil))))
+  (global-set-key (kbd "C-c C-c") 'mc/edit-lines)
+  (global-set-key (kbd "C-<") 'mc/mark-previous-like-this)
+  (global-set-key (kbd "C->") 'mc/mark-next-like-this)
+  (global-set-key (kbd "C-*") 'mc/mark-all-like-this))
 
 (use-package expand-region
   :bind
-  (("H-=" . er/expand-region)
-   ("H-/" . er/mark-symbol)
-   ("H--" . er/contract-region)))
+  (("s-=" . er/expand-region)
+   ("s-/" . er/mark-symbol)
+   ("s--" . er/contract-region)))
 
 (use-package hungry-delete
   :ensure t

--- a/modules/core.module.el
+++ b/modules/core.module.el
@@ -14,7 +14,7 @@
 ;; Jump to things in Emacs tree-style
 (use-package avy
   :ensure t
-  :bind(("C-:" . avy-goto-word-1)
+  :bind(("C-." . avy-goto-word-1)
         :map isearch-mode-map
         ("C-'" . avy-isearch)))
 
@@ -52,19 +52,6 @@
   :ensure t
   :config
   (which-key-mode 1))
-
-;; (use-package which-key-posframe
-;;   :diminish which-key-mode
-;;   :custom-face
-;;   (which-key-posframe ((t (:background "#282a36"))))
-;;   (which-key-posframe-border ((t (:background "#6272a4"))))
-;;   :config
-;;   (which-key-mode)
-;;   :custom
-;;   (which-key-idle-secondary-delay 0)
-;;   :hook
-;;   (dashboard-after-initialize . which-key-posframe-mode)
-;;   (dashboard-after-initialize . which-key-mode))
 
 (provide 'core.module)
 

--- a/modules/key-bindings.module.el
+++ b/modules/key-bindings.module.el
@@ -12,19 +12,11 @@
 (when (is-mac-p)
   (setq
     mac-right-command-modifier 'super
-    mac-command-modifier 'hyper
+    mac-command-modifier 'super
     mac-option-modifier 'meta
     mac-left-option-modifier 'meta
     mac-right-option-modifier 'meta
     mac-right-option-modifier 'nil))
-
-(when (is-windows-p)
-  (setq
-   ;; make PC keyboard's CapsLock Hyper, for emacs running on Windows.
-   (setq w32-pass-apps-to-system nil)
-   (setq w32-apps-modifier 'hyper) ; Menu/App key
-   )
-  )
 
 ;; ----------------------
 ;; Navigation and editing
@@ -47,33 +39,33 @@
 (lambda ()(interactive)
 (ignore-errors (previous-line 5))))
 
-(global-set-key (kbd "H-c") 'clipboard-kill-ring-save) ; Cmd + C copy to clipboard
-(global-set-key (kbd "H-x") 'clipboard-kill-region)    ; Cmd + X copy to clipboard
-(global-set-key (kbd "H-v") 'clipboard-yank)           ; Cmd + V paste from clipboard
+(global-set-key (kbd "s-c") 'clipboard-kill-ring-save) ; Cmd + C copy to clipboard
+(global-set-key (kbd "s-x") 'clipboard-kill-region)    ; Cmd + X copy to clipboard
+(global-set-key (kbd "s-v") 'clipboard-yank)           ; Cmd + V paste from clipboard
 
-(global-set-key (kbd "H-<backspace>") 'kill-whole-line)
+(global-set-key (kbd "s-<backspace>") 'kill-whole-line)
 (global-set-key (kbd "M-S-<backspace>") 'kill-word)
 (global-set-key (kbd "M-<delete>") 'kill-word)
 
 ;; Use =hyper= (which is =Caps Lock=) for movement and selection
-(global-set-key (kbd "H-<left>") 'beginning-of-visual-line)
-(global-set-key (kbd "H-<right>") 'end-of-visual-line)
-(global-set-key (kbd "H-<up>") 'beginning-of-buffer)
-(global-set-key (kbd "H-<down>") 'end-of-buffer)
-(global-set-key (kbd "H-l") 'goto-line)
+(global-set-key (kbd "s-<left>") 'beginning-of-visual-line)
+(global-set-key (kbd "s-<right>") 'end-of-visual-line)
+(global-set-key (kbd "s-<up>") 'beginning-of-buffer)
+(global-set-key (kbd "s-<down>") 'end-of-buffer)
+(global-set-key (kbd "s-l") 'goto-line)
 
 ;; Basic things you should expect
-(global-set-key (kbd "H-a") 'mark-whole-buffer)       ;; select all
-(global-set-key (kbd "H-s") 'save-buffer)             ;; save
-(global-set-key (kbd "H-S") 'write-file)              ;; save as
-(global-set-key (kbd "H-q") 'save-buffers-kill-emacs) ;; quit
+(global-set-key (kbd "s-a") 'mark-whole-buffer)       ;; select all
+(global-set-key (kbd "s-s") 'save-buffer)             ;; save
+(global-set-key (kbd "s-S") 'write-file)              ;; save as
+(global-set-key (kbd "s-q") 'save-buffers-kill-emacs) ;; quit
 
 ;; Regular undo-redo.
 (global-unset-key (kbd "C-z"))
 (global-set-key (kbd "C-z")   'undo-fu-only-undo)
-(global-set-key (kbd "H-z")   'undo-fu-only-undo)
+(global-set-key (kbd "s-z")   'undo-fu-only-undo)
 (global-set-key (kbd "C-S-z") 'undo-fu-only-redo)
-(global-set-key (kbd "H-r")   'undo-fu-only-redo)
+(global-set-key (kbd "s-r")   'undo-fu-only-redo)
 
 ;;; ; Upcase word and region using the same keys.
 (global-set-key (kbd "M-u") 'upcase-dwim)
@@ -94,7 +86,7 @@
 (key-chord-define-global "yy" 'yank-whole-line)
 (key-chord-define-global "sb" 'xah-select-block)
 
-(global-set-key (kbd "H-/") #'easy-mark-word)
+(global-set-key (kbd "s-/") #'easy-mark-word)
 (global-set-key (kbd "C-c f") #'counsel-recentf)
 
 ;; Make windmove work in Org mode:
@@ -107,5 +99,5 @@
 (bind-keys*("M-m f" . hydra-folding/body))
 
 ;; UUID
-(global-set-key (kbd "H-u") 'my/uuidgen-4)
+(global-set-key (kbd "s-u") 'my/uuidgen-4)
 (provide 'key-bindings.module)

--- a/modules/python.module.el
+++ b/modules/python.module.el
@@ -60,7 +60,7 @@
   (shell-pop-shell-type (quote ("ansi-term" "*ansi-term*" (lambda nil (ansi-term shell-pop-term-shell)))))
   (shell-pop-full-span t)
   :bind*
-  (("H-`" . shell-pop)))
+  (("s-`" . shell-pop)))
 
 (provide 'python.module)
 


### PR DESCRIPTION
Looks like ubuntu isn't able to keep hyper binding to caps lock
for a long time. I need to run every hour xmodmap and it's annoying.
Also simplify multiple-cursor binding, previous one hydra binding
conflict when changing multiple cursors.